### PR TITLE
Add init script setting up the key4hep nightlies ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,39 @@
-build
+# Prerequisites
+build*
+*.d
+install
+*.root
+*.png
+*.pdf
+*.log
+*.dat
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,2 @@
+# get dependencies from cvmfs (available currently only for centos7)
+source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh


### PR DESCRIPTION
and adds a few more useful things to .gitignore. Note that the init script is useful only for machines running centos7 with cvmfs installed.